### PR TITLE
Use "latest" url to get installer

### DIFF
--- a/Source/Private/Install-WinGet.ps1
+++ b/Source/Private/Install-WinGet.ps1
@@ -3,7 +3,7 @@ function Install-WinGet {
         "name": "WinGet",
         "source": "direct",
         "url": "",
-        "script": "Add-AppxPackage https://github.com/microsoft/winget-cli/releases/download/v.0.2.2521-preview/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.appxbundle -InstallAllResources"
+        "script": "Add-AppxPackage https://github.com/microsoft/winget-cli/releases/latest/download/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.appxbundle -InstallAllResources"
     }' | ConvertFrom-Json);
 
     Get-ByScript $item;


### PR DESCRIPTION
Hi!

Rather than specifically downloading v.0.2.2521-preview of the WinGet AppX installer, changing the URL slightly allows us to download the latest installer instead.